### PR TITLE
Gitea 1.20 fixups

### DIFF
--- a/theme-dark-arc.css
+++ b/theme-dark-arc.css
@@ -422,9 +422,10 @@
     --color-input-background: #1b1b1b;
     --color-input-border: #222222;
     --color-input-border-hover: #505667;
-    --color-navbar: #222222;
-    --color-navbar-transparent: #22222200;
-    --color-nav-bg: unset;
+    --color-header-wrapper: #222222;
+    --color-header-wrapper-transparent: #22222200;
+    --color-nav-bg: #222222;
+    --color-nav-hover-bg: #303030;
     --color-light: #00000028;
     --color-light-mimic-enabled: rgba(0, 0, 0, calc(40 / 255 * 222 / 255 / var(--opacity-disabled)));
     --color-light-border: #ffffff28;
@@ -446,7 +447,8 @@
     --color-project-board-bg: var(--color-secondary-light-2);
     --color-caret: var(--color-text);
     --color-reaction-bg: #ffffff12;
-    --color-reaction-active-bg: var(--color-primary-alpha-40)
+    --color-reaction-active-bg: var(--color-primary-alpha-40);
+    --color-label-text: #dbe0ea
 }
 
 ::-webkit-calendar-picker-indicator {


### PR DESCRIPTION
These changes should fix the wrong background color on the navigation bar and buttons, and labels like the GPG signature label.
I am not sure whether the background color for hovering over the nav buttons is correct and whether it looked like this on Gitea 1.19, suggestions are welcome.

Before/After
![Screenshot_20230718_111401](https://github.com/Jieiku/theme-dark-arc-gitea/assets/1520515/66dc854d-56ff-4a45-9324-4c310371c541) ![Screenshot_20230718_113046](https://github.com/Jieiku/theme-dark-arc-gitea/assets/1520515/8880062f-a097-4424-9bd0-75eb1b0a0ec0)
![Screenshot_20230718_111514](https://github.com/Jieiku/theme-dark-arc-gitea/assets/1520515/a37fa680-c46e-4550-a03d-65ed4445559e) ![Screenshot_20230718_113132](https://github.com/Jieiku/theme-dark-arc-gitea/assets/1520515/1dc1e610-d3bc-4b53-9978-17689a2dcf3a)

There is probably more that I haven't noticed yet but this at least makes the theme look not so broken anymore :)
Relevant commits for reference: https://github.com/go-gitea/gitea/commit/b6bcb79987ae3c9095fe2b2c7c0a3e4b42cdebba https://github.com/go-gitea/gitea/commit/a103b79f60948fa8ee44f95304716f3d354a8c15
There is probably more in the commit history one wants to apply to the theme as well but this pr should do it for now.

Thanks for the awesome theme.