### PR TITLE
Rebase onto gitea-dark

### DIFF
--- a/theme-dark-arc.css
+++ b/theme-dark-arc.css
@@ -1,528 +1,546 @@
-.chroma .hl {
-    background-color: #3f424d
-}
+/* @import "../chroma/dark.css"; */
+/* https://github.com/alecthomas/chroma/blob/6428fb4e65f3c1493491571c8a6a8f1add1da822/types.go#L208 */
+.chroma .bp { color: #fabd2f; } /* NameBuiltinPseudo */
+.chroma .c { color: #777e94; } /* Comment */
+.chroma .c1 { color: #777e94; } /* CommentSingle */
+.chroma .ch { color: #777e94; } /* CommentHashbang */
+.chroma .cm { color: #777e94; } /* CommentMultiline */
+.chroma .cp { color: #8ec07c; } /* CommentPreproc */
+.chroma .cpf { color: #649bc4; } /* CommentPreprocFile */
+.chroma .cs { color: #9075cd; } /* CommentSpecial */
+.chroma .dl { color: #649bc4; } /* LiteralStringDelimiter */
+.chroma .fm {} /* NameFunctionMagic */
+.chroma .g {} /* Generic */
+.chroma .gd { color: #ffffff; background-color: #5f3737; } /* GenericDeleted */
+.chroma .ge { color: #ddee30; } /* GenericEmph */
+.chroma .gh { color: #ffaa10; } /* GenericHeading */
+.chroma .gi { color: #ffffff; background-color: #3a523a; } /* GenericInserted */
+.chroma .gl {} /* GenericUnderline */
+.chroma .go { color: #777e94; } /* GenericOutput */
+.chroma .gp { color: #ebdbb2; } /* GenericPrompt */
+.chroma .gr { color: #ff4433; } /* GenericError */
+.chroma .gs { color: #ebdbb2; } /* GenericStrong */
+.chroma .gt { color: #ff7540; } /* GenericTraceback */
+.chroma .gu { color: #b8bb26; } /* GenericSubheading */
+.chroma .il { color: #649bc4; } /* LiteralNumberIntegerLong */
+.chroma .k { color: #ff7540; } /* Keyword */
+.chroma .kc { color: #649bc4; } /* KeywordConstant */
+.chroma .kd { color: #ff7540; } /* KeywordDeclaration */
+.chroma .kn { color: #ffaa10; } /* KeywordNamespace */
+.chroma .kp { color: #5f8700; } /* KeywordPseudo */
+.chroma .kr { color: #ff7540; } /* KeywordReserved */
+.chroma .kt { color: #ff7b72; } /* KeywordType */
+.chroma .l {} /* Literal */
+.chroma .ld {} /* LiteralDate */
+.chroma .m { color: #649bc4; } /* LiteralNumber */
+.chroma .mb { color: #649bc4; } /* LiteralNumberBin */
+.chroma .mf { color: #649bc4; } /* LiteralNumberFloat */
+.chroma .mh { color: #649bc4; } /* LiteralNumberHex */
+.chroma .mi { color: #649bc4; } /* LiteralNumberInteger */
+.chroma .mo { color: #649bc4; } /* LiteralNumberOct */
+.chroma .n { color: #c9d1d9; } /* Name */
+.chroma .na { color: #fabd2f; } /* NameAttribute */
+.chroma .nb { color: #fabd2f; } /* NameBuiltin */
+.chroma .nc { color: #ffaa10; } /* NameClass */
+.chroma .nd { color: #8ec07c; } /* NameDecorator */
+.chroma .ne { color: #ff7540; } /* NameException */
+.chroma .nf { color: #fabd2f; } /* NameFunction */
+.chroma .ni { color: #fabd2f; } /* NameEntity */
+.chroma .nl { color: #ff7540; } /* NameLabel */
+.chroma .nn { color: #c9d1d9; } /* NameNamespace */
+.chroma .no { color: #649bc4; } /* NameConstant */
+.chroma .nt { color: #ff7540; } /* NameTag */
+.chroma .nv { color: #ebdbb2; } /* NameVariable */
+.chroma .nx { color: #b6bac5; } /* NameOther */
+.chroma .o { color: #ff7540; } /* Operator */
+.chroma .ow { color: #5f8700; } /* OperatorWord */
+.chroma .p { color: #d2d4db; } /* Punctuation */
+.chroma .py {} /* NameProperty */
+.chroma .s { color: #b8bb26; } /* LiteralString */
+.chroma .s1 { color: #b8bb26; } /* LiteralStringSingle */
+.chroma .s2 { color: #b8bb26; } /* LiteralStringDouble */
+.chroma .sa { color: #ffaa10; } /* LiteralStringAffix */
+.chroma .sb { color: #b8bb26; } /* LiteralStringBacktick */
+.chroma .sc { color: #ffaa10; } /* LiteralStringChar */
+.chroma .sd { color: #b8bb26; } /* LiteralStringDoc */
+.chroma .se { color: #ff8540; } /* LiteralStringEscape */
+.chroma .sh { color: #b8bb26; } /* LiteralStringHeredoc */
+.chroma .si { color: #ffaa10; } /* LiteralStringInterpol */
+.chroma .sr { color: #9075cd; } /* LiteralStringRegex */
+.chroma .ss { color: #ff8540; } /* LiteralStringSymbol */
+.chroma .sx { color: #ffaa10; } /* LiteralStringOther */
+.chroma .vc { color: #649bee; } /* NameVariableClass */
+.chroma .vg { color: #649bee; } /* NameVariableGlobal */
+.chroma .vi { color: #649bee; } /* NameVariableInstance */
+.chroma .vm {} /* NameVariableMagic */
+.chroma .w { color: #7f8699; } /* TextWhitespace */
+.chroma .err {/* not styled because Chroma uses it on too many things like JSX */} /* Error */
 
-.chroma .lnt,
-.chroma .ln {
-    color: #7f7f7f
-}
-
-.chroma .k {
-    color: #f63
-}
-
-.chroma .kc {
-    color: #fa1
-}
-
-.chroma .kd {
-    color: #9daccc
-}
-
-.chroma .kn {
-    color: #fa1
-}
-
-.chroma .kp {
-    color: #5f8700
-}
-
-.chroma .kr {
-    color: #f63
-}
-
-.chroma .kt {
-    color: #9daccc
-}
-
-.chroma .na {
-    color: #8a8a8a
-}
-
-.chroma .nb,
-.chroma .bp {
-    color: #9daccc
-}
-
-.chroma .nc,
-.chroma .no {
-    color: #fa1
-}
-
-.chroma .nd {
-    color: #9daccc
-}
-
-.chroma .ni {
-    color: #fa1
-}
-
-.chroma .ne {
-    color: #af8700
-}
-
-.chroma .nf {
-    color: #9daccc
-}
-
-.chroma .nl,
-.chroma .nn {
-    color: #fa1
-}
-
-.chroma .nx,
-.chroma .nt,
-.chroma .nv {
-    color: #9daccc
-}
-
-.chroma .vc {
-    color: #f81
-}
-
-.chroma .vg,
-.chroma .vi {
-    color: #fa1
-}
-
-.chroma .s,
-.chroma .sa {
-    color: #1af
-}
-
-.chroma .sb {
-    color: #a0cc75
-}
-
-.chroma .sc,
-.chroma .dl {
-    color: #1af
-}
-
-.chroma .sd {
-    color: #6a737d
-}
-
-.chroma .s2 {
-    color: #a0cc75
-}
-
-.chroma .se {
-    color: #f63
-}
-
-.chroma .sh {
-    color: #1af
-}
-
-.chroma .si,
-.chroma .sx {
-    color: #fa1
-}
-
-.chroma .sr {
-    color: #97c
-}
-
-.chroma .s1 {
-    color: #a0cc75
-}
-
-.chroma .ss {
-    color: #fa1
-}
-
-.chroma .m,
-.chroma .mb,
-.chroma .mf,
-.chroma .mh,
-.chroma .mi,
-.chroma .il,
-.chroma .mo {
-    color: #1af
-}
-
-.chroma .o {
-    color: #f63
-}
-
-.chroma .ow {
-    color: #5f8700
-}
-
-.chroma .c,
-.chroma .ch,
-.chroma .cm,
-.chroma .c1 {
-    color: #7c8590
-}
-
-.chroma .cs {
-    color: #637d
-}
-
-.chroma .cp {
-    color: #fc6
-}
-
-.chroma .cpf {
-    color: #03dfff
-}
-
-.chroma .gd {
-    color: #fff;
-    background-color: #5f3737
-}
-
-.chroma .ge {
-    color: #ef5
-}
-
-.chroma .gr {
-    color: #f33
-}
-
-.chroma .gh {
-    color: #fa1
-}
-
-.chroma .gi {
-    color: #fff;
-    background-color: #3a523a
-}
-
-.chroma .go {
-    color: #888
-}
-
-.chroma .gp {
-    color: #555
-}
-
-.chroma .gu {
-    color: #9daccc
-}
-
-.chroma .gt {
-    color: #f63
-}
-
-.chroma .w {
-    color: #bbb
-}
-
+/* @import "../codemirror/dark.css"; */
 .CodeMirror.cm-s-default .cm-property,
 .CodeMirror.cm-s-paper .cm-property {
-    color: #a0cc75
+  color: #a0cc75;
 }
 
 .CodeMirror.cm-s-default .cm-header,
 .CodeMirror.cm-s-paper .cm-header {
-    color: #9daccc
+  color: #9daccc;
 }
 
 .CodeMirror.cm-s-default .cm-quote,
 .CodeMirror.cm-s-paper .cm-quote {
-    color: #090
+  color: #009900;
 }
 
 .CodeMirror.cm-s-default .cm-keyword,
 .CodeMirror.cm-s-paper .cm-keyword {
-    color: #cc8a61
+  color: #cc8a61;
 }
 
 .CodeMirror.cm-s-default .cm-atom,
 .CodeMirror.cm-s-paper .cm-atom {
-    color: #ef5e77
+  color: #ef5e77;
 }
 
 .CodeMirror.cm-s-default .cm-number,
 .CodeMirror.cm-s-paper .cm-number {
-    color: #ff5656
+  color: #ff5656;
 }
 
 .CodeMirror.cm-s-default .cm-def,
 .CodeMirror.cm-s-paper .cm-def {
-    color: #e4e4e4
+  color: #e4e4e4;
 }
 
 .CodeMirror.cm-s-default .cm-variable-2,
 .CodeMirror.cm-s-paper .cm-variable-2 {
-    color: #00bdbf
+  color: #00bdbf;
 }
 
 .CodeMirror.cm-s-default .cm-variable-3,
 .CodeMirror.cm-s-paper .cm-variable-3 {
-    color: #085
+  color: #008855;
 }
 
 .CodeMirror.cm-s-default .cm-comment,
 .CodeMirror.cm-s-paper .cm-comment {
-    color: #8e9ab3
+  color: #8e9ab3;
 }
 
 .CodeMirror.cm-s-default .cm-string,
 .CodeMirror.cm-s-paper .cm-string {
-    color: #a77272
+  color: #a77272;
 }
 
 .CodeMirror.cm-s-default .cm-string-2,
 .CodeMirror.cm-s-paper .cm-string-2 {
-    color: #f50
+  color: #ff5500;
 }
 
 .CodeMirror.cm-s-default .cm-meta,
 .CodeMirror.cm-s-paper .cm-meta,
 .CodeMirror.cm-s-default .cm-qualifier,
 .CodeMirror.cm-s-paper .cm-qualifier {
-    color: #ffb176
+  color: #ffb176;
 }
 
 .CodeMirror.cm-s-default .cm-builtin,
 .CodeMirror.cm-s-paper .cm-builtin {
-    color: #b7c951
+  color: #b7c951;
 }
 
 .CodeMirror.cm-s-default .cm-bracket,
 .CodeMirror.cm-s-paper .cm-bracket {
-    color: #997
+  color: #999977;
 }
 
 .CodeMirror.cm-s-default .cm-tag,
 .CodeMirror.cm-s-paper .cm-tag {
-    color: #f1d273
+  color: #f1d273;
 }
 
 .CodeMirror.cm-s-default .cm-attribute,
 .CodeMirror.cm-s-paper .cm-attribute {
-    color: #bfcc70
+  color: #bfcc70;
 }
 
 .CodeMirror.cm-s-default .cm-hr,
 .CodeMirror.cm-s-paper .cm-hr {
-    color: #999
+  color: #999999;
 }
 
 .CodeMirror.cm-s-default .cm-url,
 .CodeMirror.cm-s-paper .cm-url {
-    color: #c5cfd0
+  color: #c5cfd0;
 }
 
 .CodeMirror.cm-s-default .cm-link,
 .CodeMirror.cm-s-paper .cm-link {
-    color: #d8c792
+  color: #d8c792;
 }
 
 .CodeMirror.cm-s-default .cm-error,
 .CodeMirror.cm-s-paper .cm-error {
-    color: #dbdbeb
+  color: #dbdbeb;
 }
 
+/* @import "../markup/dark.css"; */
+.markup [src$="#gh-light-mode-only"],
+.markup [src$="#light-mode-only"],
+.markup [href$="#gh-light-mode-only"],
+.markup [href$="#light-mode-only"] {
+  display: none;
+}
+
+.markup [src$="#gh-dark-mode-only"],
+.markup [src$="#dark-mode-only"],
+.markup [href$="#gh-dark-mode-only"],
+.markup [href$="#dark-mode-only"] {
+  display: unset;
+}
+
+
+/* theme-dark-arc.css */
 :root {
-    --is-dark-theme: true;
-    --color-primary: #87ab63;
-    --color-primary-dark-1: #93b373;
-    --color-primary-dark-2: #9fbc82;
-    --color-primary-dark-3: #abc492;
-    --color-primary-dark-4: #b7cda1;
-    --color-primary-dark-5: #cfddc1;
-    --color-primary-dark-6: #e7eee0;
-    --color-primary-dark-7: #f8faf6;
-    --color-primary-light-1: #7a9e55;
-    --color-primary-light-2: #6c8c4c;
-    --color-primary-light-3: #5f7b42;
-    --color-primary-light-4: #516939;
-    --color-primary-light-5: #364626;
-    --color-primary-light-6: #1b2313;
-    --color-primary-light-7: #080b06;
-    --color-primary-alpha-10: #87ab6319;
-    --color-primary-alpha-20: #87ab6333;
-    --color-primary-alpha-30: #87ab634b;
-    --color-primary-alpha-40: #87ab6366;
-    --color-primary-alpha-50: #87ab6380;
-    --color-primary-alpha-60: #87ab6399;
-    --color-primary-alpha-70: #87ab63b3;
-    --color-primary-alpha-80: #87ab63cc;
-    --color-primary-alpha-90: #87ab63e1;
-    --color-secondary: #222222;
-    --color-secondary-dark-1: #505665;
-    --color-secondary-dark-2: #5b6273;
-    --color-secondary-dark-3: #71798e;
-    --color-secondary-dark-4: #7f8699;
-    --color-secondary-dark-5: #8c93a4;
-    --color-secondary-dark-6: #9aa0af;
-    --color-secondary-dark-7: #a8adba;
-    --color-secondary-dark-8: #b6bac5;
-    --color-secondary-dark-9: #c4c7d0;
-    --color-secondary-dark-10: #d2d4db;
-    --color-secondary-dark-11: #dfe1e6;
-    --color-secondary-dark-12: #edeef1;
-    --color-secondary-dark-13: #fbfbfc;
-    --color-secondary-light-1: #373b46;
-    --color-secondary-light-2: #292c34;
-    --color-secondary-light-3: #1c1e23;
-    --color-secondary-light-4: #0e0f11;
-    --color-secondary-alpha-10: #22222219;
-    --color-secondary-alpha-20: #22222233;
-    --color-secondary-alpha-30: #2222224b;
-    --color-secondary-alpha-40: #22222266;
-    --color-secondary-alpha-50: #22222280;
-    --color-secondary-alpha-60: #22222299;
-    --color-secondary-alpha-70: #222222b3;
-    --color-secondary-alpha-80: #222222cc;
-    --color-secondary-alpha-90: #222222e1;
-    --color-red: #db2828;
-    --color-orange: #f2711c;
-    --color-yellow: #fbbd08;
-    --color-olive: #b5cc18;
-    --color-green: #21ba45;
-    --color-teal: #00b5ad;
-    --color-blue: #2185d0;
-    --color-violet: #6435c9;
-    --color-purple: #a333c8;
-    --color-pink: #e03997;
-    --color-brown: #a5673f;
-    --color-grey: #767a85;
-    --color-black: #1e222e;
-    --color-gold: #a1882b;
-    --color-white: #ffffff;
-    --color-diff-removed-word-bg: #6f3333;
-    --color-diff-added-word-bg: #3c653c;
-    --color-diff-removed-row-bg: #3c2626;
-    --color-diff-moved-row-bg: #818044;
-    --color-diff-added-row-bg: #283e2d;
-    --color-diff-removed-row-border: #634343;
-    --color-diff-moved-row-border: #bcca6f;
-    --color-diff-added-row-border: #314a37;
-    --color-diff-inactive: #333333;
-    --color-error-border: #a53a37;
-    --color-error-bg: #331111;
-    --color-error-text: #ff4433;
-    --color-success-border: #458a57;
-    --color-success-bg: #113322;
-    --color-success-text: #6cc664;
-    --color-warning-border: #bb9d00;
-    --color-warning-bg: #3a3a30;
-    --color-warning-text: #fbbd08;
-    --color-info-border: #306090;
-    --color-info-bg: #26354c;
-    --color-info-text: #38a8e8;
-    --color-body: #111111;
-    --color-box-header: #222222;
-    --color-box-body: #111111;
-    --color-box-body-highlight: #3a3e4c;
-    --color-text-dark: #dbe0ea;
-    --color-text: #bbc0ca;
-    --color-text-light: #a6aab5;
-    --color-text-light-2: #8a8e99;
-    --color-text-light-3: #707687;
-    --color-footer: #222222;
-    --color-timeline: #4c525e;
-    --color-input-text: #d5dbe6;
-    --color-input-background: #1b1b1b;
-    --color-input-border: #222222;
-    --color-input-border-hover: #505667;
-    --color-header-wrapper: #222222;
-    --color-header-wrapper-transparent: #22222200;
-    --color-nav-bg: #222222;
-    --color-nav-hover-bg: #303030;
-    --color-light: #00000028;
-    --color-light-mimic-enabled: rgba(0, 0, 0, calc(40 / 255 * 222 / 255 / var(--opacity-disabled)));
-    --color-light-border: #ffffff28;
-    --color-hover: #ffffff10;
-    --color-active: #ffffff16;
-    --color-menu: #222222;
-    --color-card: #222222;
-    --color-markup-table-row: #ffffff06;
-    --color-markup-code-block: #1b1b1b;
-    --color-button: #333333;
-    --color-code-bg: #1b1b1b;
-    --color-code-sidebar-bg: #222222;
-    --color-shadow: #00000060;
-    --color-secondary-bg: #1b1b1b;
-    --color-text-focus: #fff;
-    --color-expand-button: #3c404d;
-    --color-placeholder-text: #6a737d;
-    --color-editor-line-highlight: var(--color-primary-light-5);
-    --color-project-board-bg: var(--color-secondary-light-2);
-    --color-caret: var(--color-text);
-    --color-reaction-bg: #ffffff12;
-    --color-reaction-active-bg: var(--color-primary-alpha-40);
-    --color-label-text: #dbe0ea
+  --is-dark-theme: true;
+  --color-primary: #87ab63;
+  --color-primary-contrast: #ffffff;
+  --color-primary-dark-1: #93b373;
+  --color-primary-dark-2: #9fbc82;
+  --color-primary-dark-3: #abc492;
+  --color-primary-dark-4: #b7cda1;
+  --color-primary-dark-5: #cfddc1;
+  --color-primary-dark-6: #e7eee0;
+  --color-primary-dark-7: #f8faf6;
+  --color-primary-light-1: #7a9e55;
+  --color-primary-light-2: #6c8c4c;
+  --color-primary-light-3: #5f7b42;
+  --color-primary-light-4: #516939;
+  --color-primary-light-5: #364626;
+  --color-primary-light-6: #1b2313;
+  --color-primary-light-7: #080b06;
+  --color-primary-alpha-10: #87ab6319;
+  --color-primary-alpha-20: #87ab6333;
+  --color-primary-alpha-30: #87ab634b;
+  --color-primary-alpha-40: #87ab6366;
+  --color-primary-alpha-50: #87ab6380;
+  --color-primary-alpha-60: #87ab6399;
+  --color-primary-alpha-70: #87ab63b3;
+  --color-primary-alpha-80: #87ab63cc;
+  --color-primary-alpha-90: #87ab63e1;
+  --color-primary-hover: var(--color-primary-light-1);
+  --color-primary-active: var(--color-primary-light-2);
+  --color-secondary: #222222;
+  --color-secondary-dark-1: #505665;
+  --color-secondary-dark-2: #5b6273;
+  --color-secondary-dark-3: #71798e;
+  --color-secondary-dark-4: #7f8699;
+  --color-secondary-dark-5: #8c93a4;
+  --color-secondary-dark-6: #9aa0af;
+  --color-secondary-dark-7: #a8adba;
+  --color-secondary-dark-8: #b6bac5;
+  --color-secondary-dark-9: #c4c7d0;
+  --color-secondary-dark-10: #d2d4db;
+  --color-secondary-dark-11: #dfe1e6;
+  --color-secondary-dark-12: #edeef1;
+  --color-secondary-dark-13: #fbfbfc;
+  --color-secondary-light-1: #454545;
+  --color-secondary-light-2: #333333;
+  --color-secondary-light-3: #242424;
+  --color-secondary-light-4: #121212;
+  --color-secondary-alpha-10: #22222219;
+  --color-secondary-alpha-20: #22222233;
+  --color-secondary-alpha-30: #2222224b;
+  --color-secondary-alpha-40: #22222266;
+  --color-secondary-alpha-50: #22222280;
+  --color-secondary-alpha-60: #22222299;
+  --color-secondary-alpha-70: #222222b3;
+  --color-secondary-alpha-80: #222222cc;
+  --color-secondary-alpha-90: #222222e1;
+  --color-secondary-button: var(--color-secondary-dark-4);
+  --color-secondary-hover: var(--color-secondary-dark-3);
+  --color-secondary-active: var(--color-secondary-dark-2);
+  /* console colors - used for actions console and console files */
+  --color-console-fg: #eeeff2;
+  --color-console-fg-subtle: #959cab;
+  --color-console-bg: #262936;
+  --color-console-border: #383c47;
+  --color-console-hover-bg: #ffffff16;
+  --color-console-active-bg: #454a57;
+  --color-console-menu-bg: #383c47;
+  --color-console-menu-border: #5c6374;
+  /* named colors */
+  --color-red: #db2828;
+  --color-orange: #f2711c;
+  --color-yellow: #fbbd08;
+  --color-olive: #b5cc18;
+  --color-green: #21ba45;
+  --color-teal: #00b5ad;
+  --color-blue: #2185d0;
+  --color-violet: #6435c9;
+  --color-purple: #a333c8;
+  --color-pink: #e03997;
+  --color-brown: #a5673f;
+  --color-black: #1e222e;
+  /* light variants - produced via Sass scale-color(color, $lightness: +10%) */
+  --color-red-light: #d15a5a;
+  --color-orange-light: #f6a066;
+  --color-yellow-light: #eaaf03;
+  --color-olive-light: #abc016;
+  --color-green-light: #93b373;
+  --color-teal-light: #00b6ad;
+  --color-blue-light: #4e96cc;
+  --color-violet-light: #9b79e4;
+  --color-purple-light: #ba6ad5;
+  --color-pink-light: #d74397;
+  --color-brown-light: #b08061;
+  --color-black-light: #3f4555;
+  /* dark 1 variants - produced via Sass scale-color(color, $lightness: -10%) */
+  --color-red-dark-1: #c23636;
+  --color-orange-dark-1: #f38236;
+  --color-yellow-dark-1: #b88a03;
+  --color-olive-dark-1: #839311;
+  --color-green-dark-1: #7a9e55;
+  --color-teal-dark-1: #00837c;
+  --color-blue-dark-1: #347cb3;
+  --color-violet-dark-1: #7b4edb;
+  --color-purple-dark-1: #a742c9;
+  --color-pink-dark-1: #be297d;
+  --color-brown-dark-1: #94674a;
+  --color-black-dark-1: #292d38;
+  /* dark 2 variants - produced via Sass scale-color(color, $lightness: -20%) */
+  --color-red-dark-2: #ad3030;
+  --color-orange-dark-2: #f16e17;
+  --color-yellow-dark-2: #a37a02;
+  --color-olive-dark-2: #74820f;
+  --color-green-dark-2: #6c8c4c;
+  --color-teal-dark-2: #00746e;
+  --color-blue-dark-2: #2e6e9f;
+  --color-violet-dark-2: #6733d6;
+  --color-purple-dark-2: #9834b9;
+  --color-pink-dark-2: #a9246f;
+  --color-brown-dark-2: #835b42;
+  --color-black-dark-2: #252832;
+  /* ansi colors used for actions console and console files */
+  --color-ansi-black: var(--color-black);
+  --color-ansi-red: var(--color-red);
+  --color-ansi-green: var(--color-green);
+  --color-ansi-yellow: var(--color-yellow);
+  --color-ansi-blue: var(--color-blue);
+  --color-ansi-magenta: var(--color-pink);
+  --color-ansi-cyan: var(--color-teal);
+  --color-ansi-white: var(--color-console-fg-subtle);
+  --color-ansi-bright-black: var(--color-black-light);
+  --color-ansi-bright-red: var(--color-red-light);
+  --color-ansi-bright-green: var(--color-green-light);
+  --color-ansi-bright-yellow: var(--color-yellow-light);
+  --color-ansi-bright-blue: var(--color-blue-light);
+  --color-ansi-bright-magenta: var(--color-pink-light);
+  --color-ansi-bright-cyan: var(--color-teal-light);
+  --color-ansi-bright-white: var(--color-console-fg);
+  /* other colors */
+  --color-grey: #767a85;
+  --color-grey-light: #828f99;
+  --color-gold: #a1882b;
+  --color-white: #ffffff;
+  --color-diff-removed-word-bg: #6f3333;
+  --color-diff-added-word-bg: #3c653c;
+  --color-diff-removed-row-bg: #3c2626;
+  --color-diff-moved-row-bg: #818044;
+  --color-diff-added-row-bg: #283e2d;
+  --color-diff-removed-row-border: #634343;
+  --color-diff-moved-row-border: #bcca6f;
+  --color-diff-added-row-border: #314a37;
+  --color-diff-inactive: var(--color-secondary-light-2);
+  --color-error-border: #a53a37;
+  --color-error-bg: #331111;
+  --color-error-bg-active: #593333; /* new */
+  --color-error-bg-hover: #472424; /* new */
+  --color-error-text: #ff4433;
+  --color-success-border: #458a57;
+  --color-success-bg: #113322;
+  --color-success-text: #6cc664;
+  --color-warning-border: #bb9d00;
+  --color-warning-bg: #3a3a30;
+  --color-warning-text: #fbbd08;
+  --color-info-border: #306090;
+  --color-info-bg: #26354c;
+  --color-info-text: #38a8e8;
+  --color-red-badge: #db2828;
+  --color-red-badge-bg: #db28281a;
+  --color-red-badge-hover-bg: #db28284d;
+  --color-green-badge: #21ba45;
+  --color-green-badge-bg: #21ba451a;
+  --color-green-badge-hover-bg: #21ba454d;
+  --color-yellow-badge: #fbbd08;
+  --color-yellow-badge-bg: #fbbd081a;
+  --color-yellow-badge-hover-bg: #fbbd084d;
+  --color-orange-badge: #f2711c;
+  --color-orange-badge-bg: #f2711c1a;
+  --color-orange-badge-hover-bg: #f2711c4d;
+  --color-git: #f05133;
+  /* Icon colors (PR/Issue/...) */
+  --color-icon-green: var(--color-green);
+  --color-icon-red: var(--color-red);
+  --color-icon-purple: var(--color-purple);
+  /* target-based colors */
+  --color-body: #111111;
+  --color-box-header: var(--color-secondary);
+  --color-box-body: #111111;
+  --color-box-body-highlight: #3a3e4c;
+  --color-text-dark: #dbe0ea;
+  --color-text: #bbc0ca;
+  --color-text-light: #a6aab5;
+  --color-text-light-1: #989ca6; /* new */
+  --color-text-light-2: #8a8e99;
+  --color-text-light-3: #707687;
+  --color-footer: var(--color-nav-bg);
+  --color-timeline: #4c525e;
+  --color-input-text: var(--color-text-dark); /* alt #d5dbe6 */
+  --color-input-background: #1b1b1b;
+  --color-input-toggle-background: #2e353b;
+  --color-input-border: var(--color-secondary);
+  --color-input-border-hover: var(--color-secondary-dark-1);
+  --color-light: #00000028;
+  --color-light-mimic-enabled: rgba(0, 0, 0, calc(40 / 255 * 222 / 255 / var(--opacity-disabled)));
+  --color-light-border: #ffffff28;
+  --color-hover: #ffffff10;
+  --color-active: #ffffff16;
+  --color-menu: var(--color-secondary);
+  --color-card: var(--color-secondary);
+  --color-markup-table-row: #ffffff06;
+  --color-markup-code-block: #1b1b1b12;
+  --color-markup-code-inline: #1b1b1b28; /* new */
+  --color-button: var(--color-secondary-light-2);
+  --color-code-bg: #1b1b1b;
+  --color-shadow: #00000060;
+  --color-secondary-bg: #1b1b1b;
+  --color-expand-button: #3c404d;
+  --color-placeholder-text: var(--color-text-light-3); /* alt #6a737d */
+  --color-editor-line-highlight: var(--color-primary-light-5);
+  --color-project-column-bg: var(--color-secondary-light-2);
+  --color-caret: var(--color-text); /* should ideally be --color-text-dark, see #15651 */
+  --color-reaction-bg: #ffffff12;
+  --color-reaction-hover-bg: var(--color-primary-light-4);
+  --color-reaction-active-bg: var(--color-primary-alpha-40);
+  --color-tooltip-text: var(--color-text-dark);
+  --color-tooltip-bg: #000000f0;
+  --color-nav-bg: var(--color-secondary);
+  --color-nav-hover-bg: var(--color-hover);
+  --color-nav-text: var(--color-text); /* alt --color-text-dark */
+  --color-secondary-nav-bg: var(--color-secondary);
+  --color-label-text: var(--color-text);
+  --color-label-bg: #333333ff;
+  --color-label-hover-bg: #333333b4;
+  --color-label-active-bg: #33333378;
+  --color-accent: var(--color-primary-light-1);
+  --color-small-accent: var(--color-primary-light-5);
+  --color-highlight-fg: #87651e;
+  --color-highlight-bg: #352c1c;
+  --color-overlay-backdrop: #080808c0;
+  /* pattern colors for image diff */
+  --checkerboard-color-1: #313131;
+  --checkerboard-color-2: #212121;
+  accent-color: var(--color-accent);
+  color-scheme: dark;
+}
+
+/* invert emojis that are hard to read otherwise */
+.emoji[aria-label="check mark"],
+.emoji[aria-label="currency exchange"],
+.emoji[aria-label="TOP arrow"],
+.emoji[aria-label="END arrow"],
+.emoji[aria-label="ON! arrow"],
+.emoji[aria-label="SOON arrow"],
+.emoji[aria-label="heavy dollar sign"],
+.emoji[aria-label="copyright"],
+.emoji[aria-label="registered"],
+.emoji[aria-label="trade mark"],
+.emoji[aria-label="multiply"],
+.emoji[aria-label="plus"],
+.emoji[aria-label="minus"],
+.emoji[aria-label="divide"],
+.emoji[aria-label="curly loop"],
+.emoji[aria-label="double curly loop"],
+.emoji[aria-label="wavy dash"],
+.emoji[aria-label="paw prints"],
+.emoji[aria-label="musical note"],
+.emoji[aria-label="musical notes"] {
+  filter: invert(100%) hue-rotate(180deg);
 }
 
 ::-webkit-calendar-picker-indicator {
-    filter: invert(.8)
+  filter: invert(.8)
 }
 
 .ui.horizontal.segments>.segment {
-    background-color: #111111
+  background-color: #111111
 }
 
 .ui.green.progress .bar {
-    background-color: #684
+  background-color: #684
 }
 
 .ui.progress.success .bar {
-    background-color: #7b9e57 !important
+  background-color: #7b9e57 !important
 }
 
 .following.bar.light {
-    background: #222222;
-    border-color: var(--color-secondary-alpha-40)
+  background: var(--color-secondary);
+  border-color: var(--color-secondary-alpha-40)
 }
 
 .following.bar .top.menu a.item:hover {
-    color: #fff
+  color: #fff
 }
 
 .feeds .list ul li.private {
-    background: #353945
+  background: #353945
 }
 
 .ui.red.label,
 .ui.red.labels .label {
-    background-color: #7d3434 !important;
-    border-color: #8a2121 !important
+  background-color: #7d3434 !important;
+  border-color: #8a2121 !important
 }
 
 .ui.yellow.label,
 .ui.yellow.labels .label {
-    border-color: #664d02 !important;
-    background-color: #936e00 !important
+  border-color: #664d02 !important;
+  background-color: #936e00 !important
 }
 
 .ui.accordion .title:not(.ui) {
-    color: #dbdbdb
+  color: #dbdbdb
 }
 
 .ui.green.label,
 .ui.green.labels .label,
 .ui.basic.green.label {
-    background-color: #2d693b !important;
-    border-color: #2d693b !important
+  background-color: #2d693b !important;
+  border-color: #2d693b !important
 }
 
 .ui.green.labels a.label:hover,
 .ui.basic.green.labels a.label:hover,
 a.ui.ui.ui.green.label:hover,
 a.ui.basic.green.label:hover {
-    background-color: #3d794b !important;
-    border-color: #3d794b !important;
-    color: #fff !important
+  background-color: #3d794b !important;
+  border-color: #3d794b !important;
+  color: #fff !important
 }
 
 .ui.divider:not(.vertical):not(.horizontal) {
-    border-bottom-color: var(--color-secondary);
-    border-top-color: transparent
+  border-bottom-color: var(--color-secondary);
+  border-top-color: transparent
 }
 
 .form .help {
-    color: #7f8699
+  color: #7f8699
 }
 
 .ui .text.light.grey {
-    color: #7f8699 !important
+  color: #7f8699 !important
 }
 
 .ui.form .fields.error .field textarea,
@@ -553,9 +571,9 @@ a.ui.basic.green.label:hover {
 .ui.form .field.error input[type=text],
 .ui.form .field.error input[type=file],
 .ui.form .field.error input[type=url] {
-    background-color: #522;
-    border: 1px solid #7d3434;
-    color: #f9cbcb
+  background-color: #522;
+  border: 1px solid #7d3434;
+  color: #f9cbcb
 }
 
 .ui.form .field.error select:focus,
@@ -571,227 +589,204 @@ a.ui.basic.green.label:hover {
 .ui.form .field.error input[type=text]:focus,
 .ui.form .field.error input[type=file]:focus,
 .ui.form .field.error input[type=url]:focus {
-    background-color: #522;
-    border: 1px solid #a04141;
-    color: #f9cbcb
+  background-color: #522;
+  border: 1px solid #a04141;
+  color: #f9cbcb
 }
 
 .ui.green.button,
 .ui.green.buttons .button {
-    background-color: #446611
+  background-color: #446611
 }
 
 .ui.green.button:hover,
 .ui.green.buttons .button:hover {
-    background-color: #448811
+  background-color: #448811
 }
 
 .ui.search>.results {
-    background: #111111;
-    border-color: var(--color-secondary)
+  background: #111111;
+  border-color: var(--color-secondary)
 }
 
 .ui.search>.results .result:hover,
 .ui.category.search>.results .category .result:hover {
-    background: var(--color-secondary)
+  background: var(--color-secondary)
 }
 
 .ui.search>.results .result .title {
-    color: #dbdbdb
+  color: #dbdbdb
 }
 
 .ui.table>thead>tr>th {
-    background: var(--color-secondary);
-    color: #dbdbdb !important
+  background: var(--color-secondary);
+  color: #dbdbdb !important
 }
 
 .repository.file.list #repo-files-table tr {
-    background: #111111
+  background: #111111
 }
 
 .repository.file.list #repo-files-table tr:hover {
-    background-color: #303030 !important
+  background-color: #303030 !important
 }
 
 .overflow.menu .items .item {
-    color: #9d9d9d
+  color: #9d9d9d
 }
 
 .overflow.menu .items .item:hover {
-    color: #dbdbdb
+  color: #dbdbdb
 }
 
 .ui.list>.item>.content {
-    color: var(--color-secondary-dark-6) !important
+  color: var(--color-secondary-dark-6) !important
 }
 
 .repository .navbar .active.item,
 .repository .navbar .active.item:hover {
-    border-color: transparent !important
+  border-color: transparent !important
 }
 
 .repository .diff-stats li {
-    border-color: var(--color-secondary)
+  border-color: var(--color-secondary)
 }
 
 .tag-code,
 .tag-code td {
-    background: #353945 !important
+  background: #353945 !important
 }
 
 .tag-code td.lines-num {
-    background-color: var(--color-box-body-highlight) !important
+  background-color: var(--color-box-body-highlight) !important
 }
 
 .tag-code td.lines-type-marker,
 td.blob-hunk {
-    color: #dbdbdb !important
+  color: #dbdbdb !important
 }
 
 .tag-code .blob-excerpt:hover {
-    background-color: var(--color-hover) !important;
+  background-color: var(--color-hover) !important;
 }
 
 .ui.red.button,
 .ui.red.buttons .button {
-    background-color: #7d3434
+  background-color: #7d3434
 }
 
 .ui.red.button:hover,
 .ui.red.buttons .button:hover {
-    background-color: #984646
+  background-color: #984646
 }
 
 .ui.list .list>.item .header,
 .ui.list>.item .header {
-    color: #dedede
+  color: #dedede
 }
 
 .ui.list .list>.item .description,
 .ui.list>.item .description {
-    color: var(--color-secondary-dark-6)
+  color: var(--color-secondary-dark-6)
 }
 
 .repository.labels .ui.basic.black.label {
-    background-color: #bbb !important
+  background-color: #bbb !important
 }
 
 .lines-num {
-    color: var(--color-secondary-dark-6) !important;
-    border-color: var(--color-secondary) !important
+  color: var(--color-secondary-dark-6) !important;
+  border-color: var(--color-secondary) !important
 }
 
 td.blob-excerpt {
-    background-color: #00000026
+  background-color: #00000026
 }
 
 .lines-code.active,
 .lines-code .active {
-    background: #534d1b !important
+  background: #534d1b !important
 }
 
 .ui.ui.ui.ui.table tr.active,
 .ui.ui.table td.active {
-    color: #dbdbdb
+  color: #dbdbdb
 }
 
 .ui.active.label {
-    background: #303030;
-    border-color: #303030;
-    color: #dbdbdb
+  background: #303030;
+  border-color: #303030;
+  color: #dbdbdb
 }
 
 .ui.header .sub.header {
-    color: var(--color-secondary-dark-6)
+  color: var(--color-secondary-dark-6)
 }
 
 .ui.dividing.header {
-    border-bottom: 1px solid var(--color-secondary)
+  border-bottom: 1px solid var(--color-secondary)
 }
 
 .ui.modal>.header {
-    background: var(--color-secondary);
-    color: #dbdbdb
+  background: var(--color-secondary);
+  color: #dbdbdb
 }
 
 .ui.modal>.actions {
-    background: var(--color-secondary);
-    border-color: var(--color-secondary)
+  background: var(--color-secondary);
+  border-color: var(--color-secondary)
 }
 
 .ui.modal>.content {
-    background: #111111
+  background: #111111
 }
 
 .minicolors-panel {
-    background: var(--color-secondary) !important;
-    border-color: #6a737d !important
-}
-
-.emoji[aria-label="check mark"],
-.emoji[aria-label="currency exchange"],
-.emoji[aria-label="TOP arrow"],
-.emoji[aria-label="END arrow"],
-.emoji[aria-label="ON! arrow"],
-.emoji[aria-label="SOON arrow"],
-.emoji[aria-label="heavy dollar sign"],
-.emoji[aria-label=copyright],
-.emoji[aria-label=registered],
-.emoji[aria-label="trade mark"],
-.emoji[aria-label=multiply],
-.emoji[aria-label=plus],
-.emoji[aria-label=minus],
-.emoji[aria-label=divide],
-.emoji[aria-label="curly loop"],
-.emoji[aria-label="double curly loop"],
-.emoji[aria-label="wavy dash"],
-.emoji[aria-label="paw prints"],
-.emoji[aria-label="musical note"],
-.emoji[aria-label="musical notes"] {
-    filter: invert(100%) hue-rotate(180deg)
+  background: var(--color-secondary) !important;
+  border-color: #6a737d !important
 }
 
 .edit-diff>div>.ui.table {
-    border-left-color: var(--color-secondary) !important;
-    border-right-color: var(--color-secondary) !important
+  border-left-color: var(--color-secondary) !important;
+  border-right-color: var(--color-secondary) !important
 }
 
 footer .container .links>* {
-    border-left-color: #888
+  border-left-color: #888
 }
 
 .repository.release #release-list>li .detail .dot {
-    background-color: #505667;
-    border-color: #111111
+  background-color: #505667;
+  border-color: #111111
 }
 
 .tribute-container {
-    box-shadow: 0 .25rem .5rem #0009
+  box-shadow: 0 .25rem .5rem #0009
 }
 
 .repository .repo-header .ui.huge.breadcrumb.repo-title .repo-header-icon .avatar {
-    color: #222222
+  color: var(--color-secondary)
 }
 
 img[src$="/img/matrix.svg"] {
-    filter: invert(80%)
+  filter: invert(80%)
 }
 
 .is-loading:after {
-    border-color: #4a4c58 #4a4c58 #d7d7da #d7d7da
+  border-color: #4a4c58 #4a4c58 #d7d7da #d7d7da
 }
 
 .markup-block-error {
-    border: 1px solid rgba(121, 71, 66, .5) !important;
-    border-bottom: none !important
+  border: 1px solid rgba(121, 71, 66, .5) !important;
+  border-bottom: none !important
 }
 
 .ui.blue.button {
-    background-color: #222222 !important;
+  background-color: var(--color-secondary) !important;
 }
 
 .ui.basic.blue.button {
-    box-shadow: inset 0 0 0 1px #444444 !important;
+  box-shadow: inset 0 0 0 1px #444444 !important;
 }
 
 .ui.blue.button:focus {


### PR DESCRIPTION
This is mostly a rebase onto the [gitea-dark](https://codeberg.org/forgejo/forgejo/src/branch/forgejo/web_src/css/themes/theme-gitea-dark.css) theme. Note that I used the css file from Forgejo as I've migrated to that recently but the theme is identical to Gitea upstream and should therefore also work for Gitea. This patch should also make it compatible with Gitea 1.22 but I haven't tested that as Forgejo is still on the 1.21 base.

I've pretty much only transferred the values from the original up until [line 471](https://github.com/Jieiku/theme-dark-arc-gitea/blob/077fb86fd6b4a4bf7eb0de6b4e13f6441f29dca8/theme-dark-arc.css#L471) (and interpolated missing/new values).
The mess after that is from the original theme that I didn't want to touch yet as it may need a rework anyway as many of the rules don't apply anymore and many of the theme's button colours use different shades of green that I want to fix in a separate pr.